### PR TITLE
Drop support for pre-1.10 Julia

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -19,8 +19,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.6' # earliest supported version
-          - '1.7' # earliest version all tests run on
+          - '1.10' # earliest supported version
           - '1' # current release
           - 'beta'
           - 'nightly'

--- a/Project.toml
+++ b/Project.toml
@@ -1,11 +1,10 @@
 name = "ExplicitImports"
 uuid = "7d51a73a-1435-4ff3-83d9-f097790105c7"
 authors = ["Eric P. Hanson"]
-version = "1.12.0"
+version = "1.12.1"
 
 [deps]
 AbstractTrees = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"
-Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"
 JuliaSyntax = "70703baa-626e-46a2-a12c-08ffd08c73b4"
 Markdown = "d6f4376e-aef5-505a-96c1-9c027394607a"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
@@ -27,12 +26,13 @@ Reexport = "1.2.2"
 TOML = "<0.0.1, 1"
 Test = "<0.0.1, 1"
 UUIDs = "<0.0.1, 1"
-julia = "1.6"
+julia = "1.10"
 
 [apps.explicit-imports-jl]
 
 [extras]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
+Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"
 DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"
@@ -41,4 +41,4 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 
 [targets]
-test = ["Aqua", "DataFrames", "LinearAlgebra", "Logging", "UUIDs", "Reexport", "Test"]
+test = ["Aqua", "Compat", "DataFrames", "LinearAlgebra", "Logging", "UUIDs", "Reexport", "Test"]

--- a/docs/src/internals.md
+++ b/docs/src/internals.md
@@ -22,4 +22,5 @@ ExplicitImports.get_names_used
 ExplicitImports.analyze_all_names
 ExplicitImports.inspect_session
 ExplicitImports.FileAnalysis
+ExplicitImports.get_default_skip_pairs
 ```

--- a/src/ExplicitImports.jl
+++ b/src/ExplicitImports.jl
@@ -7,7 +7,6 @@ using JuliaSyntax, AbstractTrees
 using JuliaSyntax: parse
 using AbstractTrees: parent
 using TOML: TOML, parsefile
-using Compat: Compat, @compat
 using Markdown: Markdown
 using PrecompileTools: @setup_workload, @compile_workload
 using Pkg: Pkg
@@ -147,7 +146,7 @@ function using_statements(io::IO, rows; linewidth=80, show_locations=false,
     indent = 0
     first = true
     for (mod, row) in zip(chosen, rows)
-        @compat (; name, location) = row
+        (; name, location) = row
         if show_locations || mod !== prev_mod || separate_lines
             cur_line_width = 0
             loc = show_locations ? " # used at $(location)" : ""
@@ -402,6 +401,5 @@ include("precompile.jl")
         sprint(print_explicit_imports, ExplicitImports, @__FILE__; context=:color => true)
     end
 end
-
 
 end

--- a/src/checks.jl
+++ b/src/checks.jl
@@ -305,9 +305,7 @@ See also: [`improper_qualified_accesses`](@ref) for programmatic access and the 
 """
 function check_all_qualified_accesses_via_owners(mod::Module, file=pathof(mod);
                                                  ignore::Tuple=(),
-                                                 skip::TUPLE_MODULE_PAIRS=(Base => Core,
-                                                                           Compat => Base,
-                                                                           Compat => Core),
+                                                 skip::TUPLE_MODULE_PAIRS=get_default_skip_pairs(),
                                                  require_submodule_access=false,
                                                  allow_internal_accesses=true)
     check_file(file)
@@ -522,9 +520,7 @@ See also: [`improper_explicit_imports`](@ref) for programmatic access to such im
 """
 function check_all_explicit_imports_via_owners(mod::Module, file=pathof(mod);
                                                ignore::Tuple=(),
-                                               skip::TUPLE_MODULE_PAIRS=(Base => Core,
-                                                                         Compat => Base,
-                                                                         Compat => Core),
+                                               skip::TUPLE_MODULE_PAIRS=get_default_skip_pairs(),
                                                allow_internal_imports=true,
                                                require_submodule_import=false)
     check_file(file)

--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -17,7 +17,7 @@ function stale_explicit_imports_nonrecursive(mod::Module, file=pathof(mod);
     check_file(file)
     @warn "[stale_explicit_imports_nonrecursive] deprecated in favor of `improper_explicit_imports_nonrecursive`" _id = :explicit_imports_stale_explicit_imports maxlog = 1
 
-    @compat (; unnecessary_explicit_import, tainted) = filter_to_module(file_analysis, mod)
+    (; unnecessary_explicit_import, tainted) = filter_to_module(file_analysis, mod)
     tainted && strict && return nothing
     ret = [(; nt.name, nt.location) for nt in unnecessary_explicit_import]
     return unique!(nt -> nt.name, sort!(ret))

--- a/src/get_names_used.jl
+++ b/src/get_names_used.jl
@@ -557,7 +557,7 @@ function analyze_per_usage_info(per_usage_info)
     #   2. Otherwise, if first usage is assignment, then it is local, otherwise it is global
     seen = Dict{@NamedTuple{name::Symbol,scope_path::SyntaxNodeList},Bool}()
     return map(per_usage_info) do nt
-        @compat if (; nt.name, scope_path=SyntaxNodeList(nt.scope_path)) in keys(seen)
+        if (; nt.name, scope_path=SyntaxNodeList(nt.scope_path)) in keys(seen)
             return PerUsageInfo(; nt..., first_usage_in_scope=false,
                                 external_global_name=missing,
                                 analysis_code=IgnoredNonFirst)

--- a/src/improper_explicit_imports.jl
+++ b/src/improper_explicit_imports.jl
@@ -2,7 +2,7 @@ function analyze_explicitly_imported_names(mod::Module, file=pathof(mod);
                                            # private undocumented kwarg for hoisting this analysis
                                            file_analysis=get_names_used(file))
     check_file(file)
-    @compat (; per_usage_info, unnecessary_explicit_import, tainted) = filter_to_module(file_analysis,
+    (; per_usage_info, unnecessary_explicit_import, tainted) = filter_to_module(file_analysis,
                                                                                         mod)
     stale_imports = Set((; nt.name, nt.module_path) for nt in unnecessary_explicit_import)
 
@@ -143,6 +143,22 @@ function process_explicitly_imported_row(row, mod)
             public_import=public_or_exported(current_mod, row.name),)
 end
 
+
+"""
+    get_default_skip_pairs()
+
+Returns a tuple of module pairs: either `(Base => Core,)` is Compat.jl is not loaded, or `(Base => Core, Compat => Base, Compat => Core)` if it is.
+"""
+function get_default_skip_pairs()
+    pkgid = Base.PkgId(Base.UUID("34da2185-b29b-5c13-b0c7-acf172513d20"), "Compat")
+    Compat = get(Base.loaded_modules, pkgid, nothing)
+    if Compat === nothing
+        return (Base => Core,)
+    else
+        return (Base => Core, Compat => Base, Compat => Core)
+    end
+end
+
 """
     improper_explicit_imports_nonrecursive(mod::Module, file=pathof(mod); strict=true, skip=(Base => Core,
                                                                          Compat => Base,
@@ -154,9 +170,7 @@ A non-recursive version of [`improper_explicit_imports`](@ref), meaning it only 
 If `strict=true`, then returns `nothing` if `mod` could not be fully analyzed.
 """
 function improper_explicit_imports_nonrecursive(mod::Module, file=pathof(mod);
-                                                skip=(Base => Core,
-                                                      Compat => Base,
-                                                      Compat => Core),
+                                                skip=get_default_skip_pairs(),
                                                 strict=true,
                                                 allow_internal_imports=true,
                                                 # private undocumented kwarg for hoisting this analysis
@@ -236,9 +250,7 @@ However, the result will be a Tables.jl-compatible row-oriented table (for each 
 See also [`print_explicit_imports`](@ref) to easily compute and print these results, [`improper_explicit_imports_nonrecursive`](@ref) for a non-recursive version which ignores submodules, as well as [`check_no_stale_explicit_imports`](@ref), [`check_all_explicit_imports_via_owners`](@ref), and [`check_all_explicit_imports_are_public`](@ref) for specific regression-testing helpers.
 """
 function improper_explicit_imports(mod::Module, file=pathof(mod); strict=true,
-                                   skip=(Base => Core,
-                                         Compat => Base,
-                                         Compat => Core),
+                                   skip=get_default_skip_pairs(),
                                    allow_internal_imports=true)
     check_file(file)
     submodules = find_submodules(mod, file)

--- a/src/improper_qualified_accesses.jl
+++ b/src/improper_qualified_accesses.jl
@@ -5,7 +5,7 @@ function analyze_qualified_names(mod::Module, file=pathof(mod);
                                  # private undocumented kwarg for hoisting this analysis
                                  file_analysis=get_names_used(file))
     check_file(file)
-    @compat (; per_usage_info, tainted) = filter_to_module(file_analysis, mod)
+    (; per_usage_info, tainted) = filter_to_module(file_analysis, mod)
     # Do we want to do anything with `tainted`? This means there is unanalyzable code here
     # Probably that means we could miss qualified names to report, but not that
     # something there would invalidate the qualified names with issues we did find.
@@ -123,9 +123,7 @@ julia> (; row.name, row.accessing_from, row.whichmodule)
 ```
 """
 function improper_qualified_accesses_nonrecursive(mod::Module, file=pathof(mod);
-                                                  skip=(Base => Core,
-                                                        Compat => Base,
-                                                        Compat => Core),
+                                                  skip=get_default_skip_pairs(),
                                                   allow_internal_accesses=true,
                                                   # deprecated, does nothing
                                                   require_submodule_access=nothing,
@@ -221,9 +219,7 @@ julia> (; row.name, row.accessing_from, row.whichmodule)
 ```
 """
 function improper_qualified_accesses(mod::Module, file=pathof(mod);
-                                     skip=(Base => Core,
-                                           Compat => Base,
-                                           Compat => Core),
+                                     skip=get_default_skip_pairs(),
                                      allow_internal_accesses=true,
                                      # deprecated
                                      require_submodule_access=nothing)

--- a/test/main.jl
+++ b/test/main.jl
@@ -45,22 +45,20 @@ end
                    "is not a supported flag, directory, or file. See the output of `--help` for usage details")
 end
 
-if VERSION >= v"1.9-" # test only when we have package extensions, for simplicity
-    @testset "Test checks" begin
-        # Expected failure on no_implicit_imports due to DataFramesExt
-        dir = joinpath(@__DIR__, "TestPkg")
-        expected_failure = ["no_implicit_imports"]
+@testset "Test checks" begin
+    # Expected failure on no_implicit_imports due to DataFramesExt
+    dir = joinpath(@__DIR__, "TestPkg")
+    expected_failure = ["no_implicit_imports"]
 
-        @testset "Specific check $check" for check in ExplicitImports.CHECKS
-            expected = check in expected_failure ? 1 : 0
-            @test ExplicitImports.main([dir, "--check", "--checklist", check]) == expected
-        end
-        @testset "All checks" begin
-            @test ExplicitImports.main([dir, "--check", "--checklist", "all"]) == 1
-        end
-        @testset "Exclude check" begin
-            checks = join("exclude_" .* expected_failure, ",")
-            @test ExplicitImports.main([dir, "--check", "--checklist", checks]) == 0
-        end
+    @testset "Specific check $check" for check in ExplicitImports.CHECKS
+        expected = check in expected_failure ? 1 : 0
+        @test ExplicitImports.main([dir, "--check", "--checklist", check]) == expected
+    end
+    @testset "All checks" begin
+        @test ExplicitImports.main([dir, "--check", "--checklist", "all"]) == 1
+    end
+    @testset "Exclude check" begin
+        checks = join("exclude_" .* expected_failure, ",")
+        @test ExplicitImports.main([dir, "--check", "--checklist", checks]) == 0
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -17,6 +17,7 @@ using ExplicitImports: is_function_definition_arg, SyntaxNodeWrapper, get_val
 using ExplicitImports: is_struct_type_param, is_struct_field_name, is_for_arg,
                        is_generator_arg, analyze_qualified_names
 using TestPkg, Markdown
+using Compat: Compat # load for compat skipping tests
 
 function exception_string(f)
     str = try

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -79,31 +79,23 @@ include("Test_Mod_Underscores.jl")
 include("module_alias.jl")
 
 @testset "ExplicitImports" begin
-    # For deprecations, we are using `maxlog`, which
-    # the TestLogger only respects in Julia 1.8+.
-    # (https://github.com/JuliaLang/julia/commit/02f7332027bd542b0701956a0f838bc75fa2eebd)
-    if VERSION >= v"1.8-"
-        @testset "deprecations" begin
-            include("deprecated.jl")
-        end
+    @testset "deprecations" begin
+        include("deprecated.jl")
     end
 
-    # package extension support needs Julia 1.9+
-    if VERSION > v"1.9-"
-        @testset "Extensions" begin
-            submods = ExplicitImports.find_submodules(TestPkg)
-            @test length(submods) == 2
-            DataFramesExt = Base.get_extension(TestPkg, :DataFramesExt)
-            @test haskey(Dict(submods), DataFramesExt)
+    @testset "Extensions" begin
+        submods = ExplicitImports.find_submodules(TestPkg)
+        @test length(submods) == 2
+        DataFramesExt = Base.get_extension(TestPkg, :DataFramesExt)
+        @test haskey(Dict(submods), DataFramesExt)
 
-            ext_imports = Dict(only_name_source(explicit_imports(TestPkg)))[DataFramesExt]
-            @test ext_imports == [(; name=:DataFrames, source=DataFrames),
-                                  (; name=:DataFrame, source=DataFrames),
-                                  (; name=:groupby, source=DataFrames)] ||
-                  ext_imports == [(; name=:DataFrames, source=DataFrames),
-                                  (; name=:DataFrame, source=DataFrames),
-                                  (; name=:groupby, source=DataFrames.DataAPI)]
-        end
+        ext_imports = Dict(only_name_source(explicit_imports(TestPkg)))[DataFramesExt]
+        @test ext_imports == [(; name=:DataFrames, source=DataFrames),
+                                (; name=:DataFrame, source=DataFrames),
+                                (; name=:groupby, source=DataFrames)] ||
+                ext_imports == [(; name=:DataFrames, source=DataFrames),
+                                (; name=:DataFrame, source=DataFrames),
+                                (; name=:groupby, source=DataFrames.DataAPI)]
     end
 
     @testset "module aliases (#106)" begin
@@ -133,22 +125,20 @@ include("module_alias.jl")
         @test isempty(improper_explicit_imports(TestMod15, "test_mods.jl")[1][2])
     end
 
-    if VERSION >= v"1.7-"
-        # https://github.com/JuliaTesting/ExplicitImports.jl/issues/70
-        @testset "Compat skipping" begin
-            @test check_all_explicit_imports_via_owners(TestMod14, "test_mods.jl") ===
-                  nothing
-            @test check_all_qualified_accesses_via_owners(TestMod14, "test_mods.jl") ===
-                  nothing
+    # https://github.com/JuliaTesting/ExplicitImports.jl/issues/70
+    @testset "Compat skipping" begin
+        @test check_all_explicit_imports_via_owners(TestMod14, "test_mods.jl") ===
+                nothing
+        @test check_all_qualified_accesses_via_owners(TestMod14, "test_mods.jl") ===
+                nothing
 
-            @test isempty(improper_explicit_imports_nonrecursive(TestMod14, "test_mods.jl"))
-            @test isempty(improper_explicit_imports(TestMod14, "test_mods.jl")[1][2])
+        @test isempty(improper_explicit_imports_nonrecursive(TestMod14, "test_mods.jl"))
+        @test isempty(improper_explicit_imports(TestMod14, "test_mods.jl")[1][2])
 
-            @test isempty(improper_qualified_accesses_nonrecursive(TestMod14,
-                                                                   "test_mods.jl"))
+        @test isempty(improper_qualified_accesses_nonrecursive(TestMod14,
+                                                                "test_mods.jl"))
 
-            @test isempty(improper_qualified_accesses(TestMod14, "test_mods.jl")[1][2])
-        end
+        @test isempty(improper_qualified_accesses(TestMod14, "test_mods.jl")[1][2])
     end
 
     @testset "imports" begin
@@ -519,17 +509,15 @@ include("module_alias.jl")
               ["using LinearAlgebra: LinearAlgebra"]
     end
 
-    if VERSION >= v"1.7-"
-        @testset "loops" begin
-            cursor = TreeCursor(SyntaxNodeWrapper("test_mods.jl"))
-            leaves = collect(Leaves(cursor))
-            @test map(get_val, filter(is_for_arg, leaves)) ==
-                  [:i, :I, :j, :k, :k, :j, :xi, :yi]
+    @testset "loops" begin
+        cursor = TreeCursor(SyntaxNodeWrapper("test_mods.jl"))
+        leaves = collect(Leaves(cursor))
+        @test map(get_val, filter(is_for_arg, leaves)) ==
+                [:i, :I, :j, :k, :k, :j, :xi, :yi]
 
-            # Tests #35
-            @test using_statement.(explicit_imports_nonrecursive(TestMod6, "test_mods.jl")) ==
-                  ["using LinearAlgebra: LinearAlgebra"]
-        end
+        # Tests #35
+        @test using_statement.(explicit_imports_nonrecursive(TestMod6, "test_mods.jl")) ==
+                ["using LinearAlgebra: LinearAlgebra"]
     end
 
     @testset "nested local scope" begin
@@ -555,15 +543,13 @@ include("module_alias.jl")
         @test map(get_val, filter(is_generator_arg, leaves)) ==
               [v; v; w; w; w; w; w]
 
-        if VERSION >= v"1.7-"
-            @test using_statement.(explicit_imports_nonrecursive(TestMod9, "test_mods.jl")) ==
-                  ["using LinearAlgebra: LinearAlgebra"]
+        @test using_statement.(explicit_imports_nonrecursive(TestMod9, "test_mods.jl")) ==
+                ["using LinearAlgebra: LinearAlgebra"]
 
-            per_usage_info, _ = analyze_all_names("test_mods.jl")
-            df = DataFrame(per_usage_info)
-            subset!(df, :module_path => ByRow(==([:TestMod9])), :name => ByRow(==(:i1)))
-            @test all(==(ExplicitImports.InternalGenerator), df.analysis_code)
-        end
+        per_usage_info, _ = analyze_all_names("test_mods.jl")
+        df = DataFrame(per_usage_info)
+        subset!(df, :module_path => ByRow(==([:TestMod9])), :name => ByRow(==(:i1)))
+        @test all(==(ExplicitImports.InternalGenerator), df.analysis_code)
     end
 
     @testset "while loops" begin
@@ -578,30 +564,28 @@ include("module_alias.jl")
               [ExplicitImports.InternalAssignment, ExplicitImports.External]
     end
 
-    if VERSION >= v"1.7-"
-        @testset "do- syntax" begin
-            @test using_statement.(explicit_imports_nonrecursive(TestMod11, "test_mods.jl")) ==
-                  ["using LinearAlgebra: LinearAlgebra",
-                   "using LinearAlgebra: Hermitian",
-                   "using LinearAlgebra: svd"]
+    @testset "do- syntax" begin
+        @test using_statement.(explicit_imports_nonrecursive(TestMod11, "test_mods.jl")) ==
+                ["using LinearAlgebra: LinearAlgebra",
+                "using LinearAlgebra: Hermitian",
+                "using LinearAlgebra: svd"]
 
-            per_usage_info, _ = analyze_all_names("test_mods.jl")
-            df = DataFrame(per_usage_info)
-            subset!(df, :module_path => ByRow(==([:TestMod11])))
+        per_usage_info, _ = analyze_all_names("test_mods.jl")
+        df = DataFrame(per_usage_info)
+        subset!(df, :module_path => ByRow(==([:TestMod11])))
 
-            I_codes = subset(df, :name => ByRow(==(:I))).analysis_code
-            @test I_codes ==
-                  [ExplicitImports.InternalFunctionArg, ExplicitImports.IgnoredNonFirst,
-                   ExplicitImports.InternalFunctionArg, ExplicitImports.IgnoredNonFirst,
-                   ExplicitImports.InternalFunctionArg, ExplicitImports.IgnoredNonFirst,
-                   ExplicitImports.InternalFunctionArg, ExplicitImports.IgnoredNonFirst]
-            svd_codes = subset(df, :name => ByRow(==(:svd))).analysis_code
-            @test svd_codes ==
-                  [ExplicitImports.InternalFunctionArg, ExplicitImports.External]
-            Hermitian_codes = subset(df, :name => ByRow(==(:Hermitian))).analysis_code
-            @test Hermitian_codes ==
-                  [ExplicitImports.External, ExplicitImports.IgnoredNonFirst]
-        end
+        I_codes = subset(df, :name => ByRow(==(:I))).analysis_code
+        @test I_codes ==
+                [ExplicitImports.InternalFunctionArg, ExplicitImports.IgnoredNonFirst,
+                ExplicitImports.InternalFunctionArg, ExplicitImports.IgnoredNonFirst,
+                ExplicitImports.InternalFunctionArg, ExplicitImports.IgnoredNonFirst,
+                ExplicitImports.InternalFunctionArg, ExplicitImports.IgnoredNonFirst]
+        svd_codes = subset(df, :name => ByRow(==(:svd))).analysis_code
+        @test svd_codes ==
+                [ExplicitImports.InternalFunctionArg, ExplicitImports.External]
+        Hermitian_codes = subset(df, :name => ByRow(==(:Hermitian))).analysis_code
+        @test Hermitian_codes ==
+                [ExplicitImports.External, ExplicitImports.IgnoredNonFirst]
     end
 
     @testset "try-catch" begin

--- a/test/test_mods.jl
+++ b/test/test_mods.jl
@@ -55,32 +55,30 @@ end
 
 end # TestMod5
 
-@static if VERSION >= v"1.7-"
-    @eval module TestMod6
+module TestMod6
 
-    using LinearAlgebra
-    using Compat: @compat
+using LinearAlgebra
+using Compat: @compat
 
-    function foo(x)
-        for (i, I) in pairs(x)
-            # this next one is very tricky, since we need to both identify `j`
-            # as a for "argument", and note that `I` is a local variable from
-            # one scope up.
-            for j in I
-            end
-        end
-        for (; k) in x
-        end
-
-        for (; k) in x, (; j) in y
-        end
-
-        for xi in x, yi in y
+function foo(x)
+    for (i, I) in pairs(x)
+        # this next one is very tricky, since we need to both identify `j`
+        # as a for "argument", and note that `I` is a local variable from
+        # one scope up.
+        for j in I
         end
     end
+    for (; k) in x
+    end
 
-    end # TestMod6
+    for (; k) in x, (; j) in y
+    end
+
+    for xi in x, yi in y
+    end
 end
+
+end # TestMod6
 
 module TestMod7
 
@@ -110,34 +108,32 @@ foo(::QR) = ()
 
 end # TestMod8
 
-@static if VERSION >= v"1.7-"
-    @eval module TestMod9
+module TestMod9
 
-    using LinearAlgebra
+using LinearAlgebra
 
-    function foo(x)
-        [x for (i1, I) in pairs(x)]
-        (x for (i2, I) in pairs(x))
-        [x for (i3, I) in pairs(x) if I == 1]
-        (x for (i4, I) in pairs(x) if I == 1)
+function foo(x)
+    [x for (i1, I) in pairs(x)]
+    (x for (i2, I) in pairs(x))
+    [x for (i3, I) in pairs(x) if I == 1]
+    (x for (i4, I) in pairs(x) if I == 1)
 
-        [x for (; i1, I) in pairs(x)]
-        (x for (; i2, I) in pairs(x))
-        [x for (; i3, I) in pairs(x) if (I, 1) == 1]
-        (x for (; i4, I) in pairs(x) if (I, 1) == 1)
+    [x for (; i1, I) in pairs(x)]
+    (x for (; i2, I) in pairs(x))
+    [x for (; i3, I) in pairs(x) if (I, 1) == 1]
+    (x for (; i4, I) in pairs(x) if (I, 1) == 1)
 
-        [x for i1 in x, I in x]
-        (x for i1 in x, I in x)
+    [x for i1 in x, I in x]
+    (x for i1 in x, I in x)
 
-        [x for i1 in x, I in x if I == 1]
-        (x for i1 in x, I in x if I == 1)
+    [x for i1 in x, I in x if I == 1]
+    (x for i1 in x, I in x if I == 1)
 
-        # Here we want to be sure that `y` does not match!
-        return (x for i1 in x, I in x if (y = 1) == 1)
-    end
-
-    end # TestMod9
+    # Here we want to be sure that `y` does not match!
+    return (x for i1 in x, I in x if (y = 1) == 1)
 end
+
+end # TestMod9
 
 module TestMod10
 
@@ -154,40 +150,38 @@ end
 
 end # TestMod10
 
-@static if VERSION > v"1.7-"
-    @eval module TestMod11
+module TestMod11
 
-    using LinearAlgebra
+using LinearAlgebra
 
-    function foo(f)
-        # This `I` is a local variable!
-        f() do I
-            return I + 1
-        end
-
-        # These are locals too, but in different scopes
-        f() do I, svd
-            return I + 1
-        end
-
-        # global, despite a local of the same name ocuring in a different scope above
-        svd
-
-        f() do (; I, z)
-            return I + 1
-        end
-
-        # This name is external
-        Hermitian() do I
-            return I + 1
-        end
-
-        # Non-first invocation of `Hermitian`
-        return Hermitian
+function foo(f)
+    # This `I` is a local variable!
+    f() do I
+        return I + 1
     end
 
-    end # TestMod11
+    # These are locals too, but in different scopes
+    f() do I, svd
+        return I + 1
+    end
+
+    # global, despite a local of the same name ocuring in a different scope above
+    svd
+
+    f() do (; I, z)
+        return I + 1
+    end
+
+    # This name is external
+    Hermitian() do I
+        return I + 1
+    end
+
+    # Non-first invocation of `Hermitian`
+    return Hermitian
 end
+
+end # TestMod11
 
 module TestMod12
 
@@ -226,14 +220,11 @@ f(norm=norm) = 1
 
 end # TestMod13
 
-if VERSION >= v"1.7-"
-    @eval module TestMod14
+module TestMod14
+using Compat: Compat, Returns
+Compat.Returns
 
-    using Compat: Compat, Returns
-    Compat.Returns
-
-    end # TestMod14
-end
+end # TestMod14
 
 # https://github.com/JuliaTesting/ExplicitImports.jl/issues/69
 module TestMod15


### PR DESCRIPTION
This drops support for julia before 1.10 now that it is the LTS, and moves Compat.jl to a test-only dependency. This is because in #121 I want to use dispatch on module parameters which requires at least 1.10. It also simplifies things by having less branching in the tests for various features.