### PR TITLE
Fix ExplicitImports to work with `--depwarn=error`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ExplicitImports"
 uuid = "7d51a73a-1435-4ff3-83d9-f097790105c7"
 authors = ["Eric P. Hanson"]
-version = "1.13.1"
+version = "1.13.2"
 
 [deps]
 Markdown = "d6f4376e-aef5-505a-96c1-9c027394607a"

--- a/src/ExplicitImports.jl
+++ b/src/ExplicitImports.jl
@@ -308,10 +308,6 @@ function filter_to_module(file_analysis::FileAnalysis, mod::Module)
     return (; needs_explicit_import, unnecessary_explicit_import, tainted, per_usage_info)
 end
 
-if VERSION < v"1.9-"
-    getglobal(mod, name) = getfield(mod, name)
-end
-
 # https://github.com/JuliaLang/julia/issues/53574
 function _parentmodule(mod)
     mod === Base && return Base
@@ -345,12 +341,8 @@ function _find_submodules(mod)
         is_submodule = try
             value = getglobal(mod, name)
             value isa Module && _parentmodule(value) == mod
-        catch e
-            if e isa UndefVarError
-                false
-            else
-                rethrow()
-            end
+        catch
+            false
         end
         if is_submodule
             submod = getglobal(mod, name)
@@ -359,8 +351,6 @@ function _find_submodules(mod)
             end
         end
     end
-    # pre-1.9, there are not package extensions
-    VERSION < v"1.9-" && return sub_modules
 
     # Add extensions to the set of submodules if present
     project_file = get_project_file(mod)


### PR DESCRIPTION
I ran into https://github.com/JuliaTesting/ExplicitImports.jl/issues/93 in a (non-public) package where tests are run with `--depwarn=error`. It seems that the problematic change was introduced in https://github.com/JuliaTesting/ExplicitImports.jl/pull/17 but as this package does not support Julia < 1.10 anymore, I reverted it.

With this PR, downstream tests do not fail anymore (but the deprecation warnings of the deprecated bindings are displayed since it is accessed with `getglobal`).

Fixes #93.

---

To some extent, the issue here is similar to https://github.com/JuliaDocs/Documenter.jl/issues/2758. In principle, one could apply the same approach as done in Base in Julia <= 1.11 and check `Base.isbindingresolved(mod, name)` before trying to access `getglobal(mod, name)` to avoid triggering the deprecation warning. However, I'm not sure if it's worth it given that Keno removed the need for `Base.isbindingresolved` (it's deprecated in 1.12 and just unconditionally returns `true`) in https://github.com/JuliaLang/julia/pull/57253, and in the same PR also remove these patterns `isbindingresolved(...) && isdefined(...)` etc. in base julia.